### PR TITLE
JSHint to check sourcecode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ build:
 	@echo "${HR}\n"
 	@echo "Create \"build\" directory"
 	@mkdir -p build/js
+	@echo "Check the source code using \"jshint\""
+	@jshint js/*.js --config js/.jshintrc
 	@echo "Minify \"upcloo.js\" sourcecode"
 	@uglifyjs -nc js/upcloo.js > build/js/upcloo.min.tmp.js	
 	@echo "/**\n * upcloo.js by @egm0121 @gmittica @wdalmut.\n * Copyright 2012 Corley, S.r.l..\n * http://opensource.org/licenses/MIT\n */" > build/js/copyright.js

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ clean:
 	@rm build/js/upcloo.min.js
 	@rmdir build/js
 	@rmdir build
+	
+force-clean:
+	echo "Force clean! PLEASE USE WITH CARE!"
+	rm -rf build

--- a/README.md
+++ b/README.md
@@ -1,40 +1,9 @@
 #upcloo-js-sdk
 
-Autocomplete JavaScript library
+UpCloo JavaScript library
 
-## Make UpCloo JS SDK
-
-You need `nodejs` and `uglify-js`.
-
-Install `uglify-js`
-
-```shell
-npm install uglify-js
-```
-
-Download and install UglifyJS
+## Developers
 
 ```
-git clone git://github.com/mishoo/UglifyJS.git
-```
-
-Link the executable
-
-```
-$ cd /usr/bin
-$ sudo ln -s ~/git/UglifyJS/bin/uglifyjs
-```
-
-### Compile
-
-Compile and minimize
-
-```
-make
-```
-
-Clean
-
-```
-make clean
+$ npm install expresso uglifyjs jshint recess -g
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,31 @@ UpCloo JavaScript library
 
 ## Developers
 
+First of all you have to install a list of dependencies
+
 ```
 $ npm install expresso uglifyjs jshint recess -g
+```
+
+After that you can compile the library
+
+```
+$ make
+```
+
+The make process dependes on library sourcecode. JSHint check the 
+library before compile the source and minimize the code.
+
+### Clean the library
+
+To clear the library compile use
+
+```
+$ make clean
+```
+
+Or to force the clean operation
+
+```
+$ make force-clean
 ```

--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -1,0 +1,10 @@
+{
+    "validthis": true,
+    "laxcomma" : true,
+    "laxbreak" : true,
+    "browser"  : true,
+    "debug"    : true,
+    "boss"     : true,
+    "expr"     : true,
+    "asi"      : true
+}


### PR DESCRIPTION
Added `jshint` support it could be useful to check the source code.

I start to add `expresso` to unit testing the library into a near future.
